### PR TITLE
Wiki slash command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+node_modules
+run-dev.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,30 @@
-FROM node:20-alpine
+FROM node:20-alpine AS builder
+RUN apk add --no-cache openssl-dev openssl-libs-static fontconfig font-dejavu \
+    python3 build-base g++ cairo-dev pango-dev giflib-dev librsvg-dev && \
+    mkdir -p /nh-discord
 
-RUN apk add --no-cache openssl-dev openssl-libs-static fontconfig font-dejavu && \
-    mkdir /nh-discord
-
-COPY commands/ /nh-discord/commands/
-COPY main.js /nh-discord/main.js
-COPY charts.js /nh-discord/charts.js
-COPY entry.sh /nh-discord/entry.sh
 COPY package*.json /nh-discord/
 
 RUN cd /nh-discord && \
-    npm install && \
-    chmod +x entry.sh
+    npm install
+
+
+# build the runtime image
+FROM node:20-alpine
+RUN apk add --no-cache openssl-dev openssl-libs-static fontconfig font-dejavu cairo-dev pango-dev giflib-dev librsvg-dev && \
+    mkdir -p /nh-discord
+
+# copy built dependecies from builder stage
+COPY --from=builder /nh-discord /nh-discord/
+
+# copy the app files
+COPY commands/ /nh-discord/commands/
+COPY slash_commands/ /nh-discord/slash_commands/
+COPY lib/ /nh-discord/lib/
+COPY main.js /nh-discord/main.js
+COPY charts.js /nh-discord/charts.js
+COPY entry.sh /nh-discord/entry.sh
+
+RUN chmod +x /nh-discord/entry.sh
 
 ENTRYPOINT ["/nh-discord/entry.sh"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,49 @@
 # nh-discord
 
 nh-discord is a discord bot for Nottingham Hackspace. Feel free to add stuff!
+
+## Local development
+
+Requirements:
+1. NodeJS
+2. Docker
+
+### 1. Create a dev bot and update the config
+
+You need a discord `token`, `clientId` and `primaryGuild`. You can create your own bot here https://discord.com/developers/applications
+
+* **Installation** 
+  * Give it `application.commands` and `bot` scopes.
+  * Give it Administrator permissions (it would be better to match the deployed bot's permissions, but for simplicity...)
+* **OAuth2** 
+  * Here you can find the client ID
+* **Bot**
+  * Enable `Privileged Gateway Intents`
+  * On this page you can get the token with the `Reset Token` button
+
+Finally, add your bot to your own private discord server, using the Discord Provided Link on the `Installation` page.
+
+You can get the `primaryGuild` by right-clicking on your server in the discord server list and using `Copy Server ID`.
+
+### 2. Start prerequisites 
+
+* MQTT
+  * `docker run -it -p 1883:1883 eclipse-mosquitto:latest mosquitto -c /mosquitto-no-auth.conf`
+
+### 3. Start the bot 
+
+You can override the config by passing secret values as environment variables:
+
+```shell
+  token=[your token] \
+  clientId=[your dev bot clientId] \
+  primaryGuild=[your private server ID] \
+  notificationChannel=[some channel ID from your server] \
+  node main.js
+```
+
+(if you create a script with this info called `run-dev.sh` and it will be ignored by git)
+
+At this point the local bot will connect to the discord application you configured and function like a normal bot 
+on your private server without needing any privileged access to the production deployment.
+

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+	"clientId": "",
     "token": "discord token",
     "mqtt": "mqtt://localhost",
     "wirelessMap": {

--- a/lib/qrcode.js
+++ b/lib/qrcode.js
@@ -1,0 +1,152 @@
+const QRCodeStyling = require("qr-code-styling");
+const {JSDOM} = require("jsdom");
+const nodeCanvas = require("canvas");
+
+/**
+ * This is https://wiki.nottinghack.org.uk/logo/nottinghack_with_white.svg as a png with base64 encoding,
+ * to avoid downloading it each time, or needing to add to the docker image.
+ */
+const nhLogoBase64 = `iVBORw0KGgoAAAANSUhEUgAAAIcAAACHCAYAAAA850oKAAAACXBIWXMAAAAAAAAAAQCEeRdzAAAQ
+AElEQVR4nO2dB3RUVRrHX52ZTJJJnRQggIDiAi5NQGANBFGWhNAhCc2yFBGUti5wKBKKkFWQKiAo
+zZWiFFdICEUgKEpRgVUE9YAsCUVcXSGgohv3fgMPk8mbybyZ995375D/Od/hHOCc3HfvL//v9stx
+QS7Byjkt8Xw7e21hYPh94tTIB8RV0SnSjtgO0pG4ztKZ+B7ydyS+T8ySf1Mioaf8A/w9+fevY/8s
+fRzdTtoV2VJcE/5HcYa9jjDEmsA/LIRwidjfVikNAhBsVYV00ojTCQA747vL35RudL2DAPSfmIek
+PeGNxBxbNaFbJTAUiRc4C/wWOxqLL8R2lI6SBisxEgZfwpkmnXA0FedZq/BpvMiFYNfRHSUChJX8
+lnYFm3dPB7RFQi/5alRrcUNIdSGDgGLHrruglRzFN4LfSJIqvsVudL9AIf2YiObiK5ZYvhV2XQaH
+eE6EPgT0H7AbV88gqedkaF1hRKWb+CHI1aTyRsZ1lQqxG9LIgA5zWH1hAi9zDuw6p14EClvovcLo
++G7yBeyGMxUSMuoJayBMIpCEY7cBjeJt1YVecenSaeyGQnaSy5BuSDqVsBuECsnR/P2xj0iHsBuG
+pnCmSp9a4vg22G2DJuiMhTcUZyVmyr9iNwalUUKG66thYg+7rUwV+a1oC1PTFDQA9UH6X5fIiK0z
+dpsZLpjAuuUW/8OudNYCXCRoO6xiGF8LFrGwK5nlcHaSTkkRfAPsttRV1ip8KqxyYlduMERCb/lH
+ey3hCew21UVh9YTxlWlE/3A0Fl8kQ14Bu339ExmrRzQTF2NXYjBHdFspl7l+CC9xYcG2HkJrwBwR
+Ge7GYre5TxIsXGTMw9IB7ErTGlX6WEoGTun3PvyJXRat4UyVPqN+oxEQTEYkH2FXlj9gLH395b2/
+Ea3c8Op7VftY2QOkk/SlGMrXwGZAVST3RcR2kA5jV5KfYOz7rZQIIAVVs6zMdaLj0qWvxBC+CjYL
+ZQRT4THtpQLsytEDDNYBgb0igo2Lx2bipgROZrHzWTqVeBKrKQYcnAwKQrHR4MhwdQl2ZfgJhqpj
+BIuDRLeRtsJOOjQwXBNcFFSEH2B4dYxgcRDXRBmGYOs9azOfWhwjWBwk5C7hUVPBgCETa7vAAwGD
+ZUASesvXYee+KWDAsjtrq6v+pBJPWrF++X7WUgyMYGDW2nA4SB6bjf2xfoARkGOoAMKcg0Q0F5cZ
+CobFyT/IUj/DCDBYBsSWJPQwBAywJZa29gEYS9Ys2mMEGKUAYWoUA1sOBSsXozscjibiXOyP0wTG
+64sMcQwVQJhyEJJelusKBhwfYGWXuJlgMApIiSWeT9GLDZ6VcyUAxvK1SwvMBEPRghUv7cX+fl/D
+2VE6rsvsaUhNoR/2x/gKhtmOoegaUZfR7T/BrgMtYa8tDArMMkTOxkIntBIM7QGd04AOcMOhZuyP
+8AWMZW8sQQEDtHDlXGbSiXuE1Rcm+u8aXaUi7A+oCAwsx1BUQjRm1nAmAYHT/X5tUA6tK4zCLjzt
+YChiGZCwesI4bWQInEzzxSm3Jrh0WSvRSwDI6FnDmNsNR/oeF2G9zGc2QmoIWdiF9goGJY7hLgBk
+1MynmHOQkFrCYz7DQfPRglZD6p8uLi6+hg2CJ/2PaNi0gUwBAqvsPoEBa//Yha0oUkckH7ty5cpV
+bBA8CRxk5MyhTKUYSyzfskI4HE3F+dgF9QmQ0cmf0wwIOMiTUx7fhV1PvgbsBfYKBnRMKNzhVZI2
+LAV2t5db/Uwfk/IZ7SlmyHOPvUtBHVYYCT3l/3q9cRluBsYupDsYM+ZnvwMVPXtpznY1QFJHJZ+g
+2UF+JWIFELi0zyMckS3F17ELWBqM5xdM3Va6omcvyclV22xEUswp6gGZ/Cj1Z3siW4lr1ckQOJmi
+C1bKgaHICyBf0A7I4EkDqAYE7mqHmfFybMDrA9iFU8CYuXDaVm8V7THFjEn+knpAJg/YTUEdewxr
+It+x/CilsfgCdsFugZHrS0V7cpC0Z5PP0A7IoIn9d1BQ16rhaCLOKQdHbEfpGDYYsxZNz9NS0V4A
++boSEP/CmSr9q2x3w8o5E3Efsil5ccksTWAogtGMWtk7j0352pdhLgw3/fm5geoXosfGZ9LYBykR
+bFzC70PYqkI6ZmGgDxFIRXsB5Kw3QH4m6jep+6czX8k+EsjP91cAyIBxvcs4SLPBd5/LWTJ9D+YN
+QzClcRsOeNgOC4y/L34+IDAUkRST5yHFnLtytXyKATD6Tux2XPl/zy0cf0iPcmgVpJi/TOibD2Vo
+9VS98+cKz12Av8c8egkXCd+GA+l+jZK5y17coWdFe3SQcSmFpR3kOlGvsanH3f8floPcIJo4Z+yu
+i5cuXi7991hHL+FRw9twGP2KohoYLyyZqYtjuMuTg3Qam3yBOEgx7Pns/tcOqns+Zy7L/siIMgWi
+1W+ueM9sB4EllJudURsXZzYY816ds9PICiUOsjVRxUG6jE+5kD66XTnHSER0DV+0+q0V75vtIK5O
+KRxwMRMMf0clWkU6uflqgLAGhqIN76w7XK2vzTRArPH8QxycXzARjHwzK9RTiikDBoWpxJMIIAeT
++oaYkmJc51rgCW+jfxAMyxaunLcbo0KnzZucx7JjuOuNzWs+NMNBYATLwdvuRoOxaNX8PRgVCcPV
+/pN6qPcxGHIMd721bcNhox0EHnWGYaxh07i3wEBxDNc8xqRunwaLY7iLAHIkqV+IYQ4S007azRl1
+HTWA8fLqBXswKu4noj4TugadY7hrY+6bhjkI4eITLq6zdCaYwGBtHiNQbcp764gRgMR1kc5yem/w
+0fNyNq2Cmc/Oox86qgpGEKQSTzIixST0lH/gEnrL1/QEY/GahWgn0eBIwN+mj1rnPnwNRsdw1+a8
+jR9V72vXzUHguTAuMUO+oRcYRt/B5auy50x6O/HWBFgwO4a7tuRv+rh6P7teDlLCJeq0jwMessGu
+nNICQAgYh43+ORcvXfzG6J+hRRPmPKvbYaqgdA6z9N6H+4/XGRBdPP+1l3ZhlwWUu2Prgep9wop1
+cw69+xy0HnLWWwSMY3X6R19VKnLG/GzV3fJmKW/ntgPVs8Ku6NWWCRnyT4aMVrAubTNLBQf2Ha3V
+L7LMb2ib4Y0KYRiNUZ5/5m3Zn5QVqpdj3ISjp3yFM+LOr2B2EDfHcAXs4Dp/4fwljPJs35X7gZ6O
+oURcF+nfnFGX3AcjIGpgPDD03qKi80UXMcpjFBgQsR2lo4ZuEQwmQNTAaPFk3aLCokIUMPJ3531Y
+IyvcEDAgXGsrRp+PDQZA1MBoPLBW0ZmzZ85hlMdoMCAiW4lvmLLznOVOqlrnEyJtVNtjxURml0fn
+4arHCG8ozuTsdYQhRv8gVh1EzTHKADKyjak3DO14d/tBox1DCcLFk6YeoGZpouzWBFeFc0BpI9p8
+YgYgLjD6hBvuGEoQLh7h4A10s36gAgjtKUYtlbR9pnHR5IVjVfe+pI9qd9TIFEP6GKaCASHa+WrK
+uRVTr3qiOcWopZK2Ixqfv/zt5e/g319amaMKiFEpZuee/IM1+zhMSSVKwBVQBAveBQeccDLzhyuA
+uN9ZDr99cJc4LL3rXcm+6NQXJ0+rOYYChiJY6TXDQQgYh8x2DIiY9tL+38/KNhJzzC6Au4OUfn3g
+6RmDCzBOvwOU4+eM2a/mGO4y2kF27d1xyGzHUALuavn9lH2S0B2jEAog8JBNp1EpZXZwwU3AWA6S
+vWjCQTXHcJdRDkLAOFyzr8N0x1CizMVxZndKfQ1MQIiRXffl/+kNyO59O49gggFxuzOqyJkmncCG
+QS2enj54H9YFK77KU4pJHZF8XEuKcY2S+kZ6nFcxI5ydpFPl7wRrKs7DBsELIHuDHZD9HxQcrd0v
+ChUMiIj7xYXl4LBW4dOwC+YVkKmDd1EPyKoc1SMRqc8ke50oI2Acq90/SrdNV4GErZrQpRwccP8k
+bPDALlwFgOykHhCNDgLzKjQ4BgTsCuQlLrQcHKCo1uJ67ALeSYDQBAZE1J/EjapggEKqCxnYBfQR
+kHzqAakgxcDaDS2pRAl4JtYjHCS12OGkE3YhfYkR04fmYw1zfRUcjVAre/unW5xQ2waAGQm95OIK
+HwOMaC4uwy6orzE8exD9DuIhxdAWkQ+IK72CAYIXe7ALqiWGTRmUSz0gq3IM2aerZ1ji+XYVwgGC
+zaXYhdUSI6YNzaM9xTzxXNYh7HryFM406XNOWYWtSPZawuPYBdYaJMVsp9VBXFv7DNolrkfY7xaG
++gQGyPWcVzf5InahNQMyZVAebYDQDkZ8D/l7j3MbngTvnGMX3J8YRhEgtIMBARcGagLD5R4y54C3
+zrELzyogLIABLzMJVi5WMxwu92ggTML+AH9j6tzJ72CBsWXbpoKkTDtV8xhq4Tp+4K9ILgqL7yqf
+x/4IrdHk8Tqfnz5z+iwGGCw4BgQcoCeuEeM3HCCzzrXoFS0H1z9ZWFR4vhIM7xFaVxgZEBg37YOT
+nKmS6n2eNMaK9ctRjj2wkkog4tKlr8iI1BI4HESWOD45EfeZL5+jWpbtxoa31+03E4zNWzfuTcqw
+M+EYENaqfCddwFAU0UJ8DfujaASENTCiWosbdAUDBJ2X+G7yJeyP8zWqZtl+3rBlnaEphoCxj5VU
+AgGHlcQQvorucIBsVYXO2B9ICyCsOQaE1/0aeoilJX2jAGERDK+7vPQSzH3A9nXsj9UIyE/rt6zV
+5WZl1lIJBNzvJVi4aMPhAEkRfAPYOYT90RoBCdhBWHQMuGfW4uRbmwKGopAaQib6h/sBCHEQv073
+MwkGidB7hOGmgqHI0Vicjf3xmgHJtP24fvPaPRrBYC6VQES2EFeggOESzwlRD4qbsCtBMyA3+yA+
+OQirjhHTXiqAfTl4cHA3d6zHPiJRuwXOIyCZtuvEQd4NRsdwpkknTeuAViTYE8DS+osvgLDqGGRk
+ck4M5WtiM1FG8LI1EItdOX4Acs0dEFbBgGfnJQd/LzYLqiLE1oAVP+xK0gxIhq2YALKb5VQCe36l
+SP4+bAa8CubuSYr5DLuytAYAMW7WmLdZBAMe65PC+Xuw294nQR8ktoOkeuNNZegbMFsNjo3d5poE
+293JMHcLduUFc8Q8LL1PfhGd2G3tn3hOdDQR52JXYjAGPCeOPo+hh2CpWM/nwu7oyJR/CasnjOV8
+Pb7IguRIviGLIxmaAjZb+XzgmTXBQamIZuJS7EpmMaLbSnlwJSh2GxouuATV7PvWWQ04lWavLQzE
+bjNTJdi4eNKpWp3IyK52jIhuI22lbircTMG7HmSs/iV2Q9AUsD5iSxJ6YLcNHRI42V5HGAxrA9gN
+gxmwuy68oTirwru57kQJFi4KKgfyLHZDmQpFb/lHR1NxAUm1CdhtQL1g+h0eJmTlZsMAoLgGk4SG
+nSUJZsFOd0g3tF7a72/AzQXh94lTAj7lXinOtR3Rmsh3iGwlrgULxm5cvyJDvgFrTbZqQlc47Mgp
+pQAAAKpJREFUnI5dpUEp0i+JhHE/TAolZMg/oze6t8iUf4WXne13C8NgMxR23d1RAlBCaghZsMs6
+rqtUiA5D1s1NN8Th/hFyl/Co31cqVUp/SQ7+D3BNZkRz8ZXYjtIxsHKDneEX2NgEcELf6NZOrOBZ
+EAtqCZwsRfD1Ybo+rJ4wPqKZuJiko1y4hBeOCFa0Ukz+/To4krOjdDw6RcoH6OCWRTjQBQuJul2A
+Qqn+Dy1/quiI07SVAAAAAElFTkSuQmCC
+`
+
+
+module.exports =  {
+    /**
+     * Generate a QR code and return it as a Stream.
+     *
+     * @param url string
+     * @param titleText string
+     * @returns {Promise<PNGStream>}
+     */
+    generateQRCode: async (url, titleText) => {
+        // For canvas type
+        const qrCode = new QRCodeStyling({
+            jsdom: JSDOM, // this is required
+            nodeCanvas, // this is required,
+            width: 300,
+            height: 300,
+            shape: 'circle',
+            margin: 0,
+            dotsOptions: {
+                color: "#000000",
+                type: "dots"
+            },
+            backgroundOptions: {
+                color: "#ffffff",
+            },
+            data: url,
+            cornersSquareOptions: {
+                type: 'dot',
+                color: '#195905',
+            },
+            cornersDotOptions: {
+                type: 'dot',
+            }
+        });
+
+        return qrCode.getRawData('png').then(async (data) => {
+            const canvas = nodeCanvas.createCanvas(500, 500)
+            const qrImage = await nodeCanvas.loadImage(data)
+            const logo60pxImage = await nodeCanvas.loadImage(new Buffer(nhLogoBase64, 'base64'))
+
+            const ctx = canvas.getContext('2d')
+
+            ctx.globalAlpha = 1
+            ctx.font = 'normal 40px Impact, sans'
+            ctx.fillStyle = '#fff'
+            ctx.fillRect(0, 0, 500, 500)
+
+            ctx.fillStyle = '#000'
+            ctx.textBaseline = 'middle'
+            ctx.textAlign = 'center'
+            ctx.fillText("WIKI PAGE", 250, 50)
+
+            ctx.fillStyle = '#195905'
+            ctx.fillText((titleText?.length ?? 0) < 20 ? titleText.toUpperCase() : '', 250, 450)
+
+            // add the QR code
+            ctx.drawImage(qrImage, 100, 100)
+
+            // add logo to center
+            ctx.drawImage(logo60pxImage, (500/2)-(60/2), (500/2)-(60/2), 60, 60)
+
+            return canvas.createPNGStream()
+        })
+    }
+}

--- a/lib/wiki.js
+++ b/lib/wiki.js
@@ -1,0 +1,25 @@
+module.exports = {
+    /**
+     * Extracts tool information from wiki page content.
+     *
+     * @param content string
+     * @param ignoredFields string[]
+     * @returns {{name: void | string, value}[]|null}
+     */
+    extractToolData: (content, ignoredFields) => {
+        const matches = (content ?? '').match(/{{Tool\n([^}]+)/g)
+        if (matches == null || matches.length === 0) {
+            return null
+        }
+       return matches[0]
+            .replaceAll("{{Tool\n", "")
+            .replaceAll("}}", "")
+            .replaceAll("\n", "")
+            .split("|")
+            .map((keyval) => {
+                [name, value] = keyval.split("=")
+                return {name, value: value || 'NA'}
+            })
+           .filter((row) => row.name && row.value && !ignoredFields.includes(row.name))
+    }
+}

--- a/main.js
+++ b/main.js
@@ -1,5 +1,12 @@
-const { Client, Events, GatewayIntentBits, AttachmentBuilder, EmbedBuilder } = require('discord.js');
+const { Client, Events, GatewayIntentBits, Routes, REST } = require('discord.js');
 const conf = require('./config.json');
+
+// override any config keys given as environment variables
+Object.keys(conf).forEach((key) => {
+    if (process.env[key] != null) {
+        conf[key] = process.env[key]
+    }
+})
 
 const mqtt = require('mqtt')
 const mqttClient = mqtt.connect(conf.mqtt)
@@ -7,6 +14,7 @@ const mqttClient = mqtt.connect(conf.mqtt)
 var BOT_USER_ID;
 
 var commands = [];
+var slashCommands = []
 
 // Create a new client instance
 const discordClient = new Client({
@@ -35,8 +43,36 @@ discordClient.on(Events.MessageCreate, function(message)  {
     });
 });
 
+/**
+ * InteractionCreate is fired for various events:
+ *   * Slash command is invoked
+ *   * Button is pressed
+ *   * Autocomplete
+ *   * Modal is submitted
+ *
+ * Try and match the events up to a command.
+ */
+discordClient.on(Events.InteractionCreate, (interaction) => {
+    // if the interaction is a button press get the command name from the interaction (todo: is there a better way?)
+    const cmd = slashCommands.find((cmd) => cmd.accept(interaction.commandName ?? interaction.message?.interaction?.commandName))
+    if (cmd) {
+        if (interaction.isAutocomplete()) {
+            cmd.autocomplete(interaction)
+        } else if (interaction.isButton()) {
+            cmd.handleButton(interaction)
+        } else if (interaction.isCommand()) {
+            cmd.execute(interaction)
+        } else {
+            console.warn("Unknown interaction type was ignored", interaction.type)
+        }
+    } else {
+        console.log(interaction)
+        console.error(`Failed to find command for interaction: ${interaction.commandName} (customId: ${interaction.customId})`)
+    }
+})
+
 discordClient.on(Events.PresenceUpdate, function(before, after) {
-    if (! after.user) return;
+    if (!after.user) return;
     if (after.user.id == BOT_USER_ID) return;
 
     commands.forEach(command => {
@@ -50,35 +86,70 @@ discordClient.on(Events.ThreadCreate, function(thread, isNewThread) {
 	thread.join();
 });
 
+mqttClient.on('error', function (err) {
+  console.error("failed to connect to MQTT", err)
+})
+
 mqttClient.on('connect', function () {
     console.log("MQTT connected");
 
     conf.mqttSubscriptions.forEach(topic => {
-	mqttClient.subscribe(topic, e => {
-	    if (!e) return;
-	    console.log(`failed to subscribe to ${topic}`);
-	});
+        mqttClient.subscribe(topic, e => {
+            if (!e) return;
+            console.log(`failed to subscribe to ${topic}`);
+        });
     });
 
     commands.forEach(command => {
-	command.discordClient = discordClient;
-	command.mqttClient = mqttClient;
+	    command.mqttClient = mqttClient;
     });
 })
 
 mqttClient.on('message', function (topic, message) {
     commands.forEach(command => {
-	command.onMqttMessage(topic, message);
+	    command.onMqttMessage(topic, message);
     });
 });
 
 // load commands
-var normalizedPath = require("path").join(__dirname, "commands");
+var commandsPath = require("path").join(__dirname, "commands");
 
-require("fs").readdirSync(normalizedPath).forEach(function(file) {
+require("fs").readdirSync(commandsPath).forEach(function(file) {
     const cmd = require("./commands/" + file);
-    commands.push(new cmd());
+    const instance = new cmd()
+    instance.discordClient = discordClient
+    commands.push(instance);
 });
 
-// Log in to Discord with your client's token
-discordClient.login(conf.token);
+var slashCommandsPath = require("path").join(__dirname, "slash_commands");
+
+require("fs").readdirSync(slashCommandsPath).forEach(function(file) {
+    const cmd = require("./slash_commands/" + file);
+    const instance = new cmd()
+    instance.discordClient = discordClient
+    slashCommands.push(instance);
+});
+
+
+/**
+ * Slash commands need to be added to the bot on start-up.
+ */
+const rest = new REST({ version: '10' }).setToken(conf.token);
+(async () => {
+    try {
+        console.log('Started refreshing slash commands.');
+        await rest.put(
+            // Get the clientID from https://discord.com/developers/applications/[application]/oauth2
+            Routes.applicationGuildCommands(conf.clientId, conf.primaryGuild),
+            { body: slashCommands.map((cmd) => cmd.configure()) },
+        );
+        console.log('Successfully reloaded slash commands.');
+    } catch (error) {
+        console.error('Failed to setup slash commands', error);
+    }
+})().finally(() => {
+    // Log in to Discord with your client's token
+    discordClient.login(conf.token);
+})
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,66 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "canvas": "^3.2.0",
         "chart.js": "^4.5.0",
         "discord.js": "^14.16.3",
         "express": "^4.21.2",
+        "jsdom": "^27.0.1",
         "mqtt": "^5.10.3",
         "prom-client": "^15.1.3",
+        "qr-code-styling": "^1.9.2",
         "skia-canvas": "^2.0.2"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.5.tgz",
+      "integrity": "sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.3.tgz",
+      "integrity": "sha512-kiGFeY+Hxf5KbPpjRLf+ffWbkos1aGo8MBfd91oxS3O57RgU3XhZrt/6UzoVF9VMpWbC3v87SRc9jxGrc9qHtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.2"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
     },
     "node_modules/@babel/runtime": {
       "version": "7.26.0",
@@ -26,6 +79,138 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+      "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -445,6 +630,15 @@
         }
       ]
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bintrees": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
@@ -545,6 +739,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/canvas": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.0.tgz",
+      "integrity": "sha512-jk0GxrLtUEmW/TmFsk2WghvgHe8B0pxGilqCL21y8lHkPUGa6FTsnCNtHPOzT8O3y+N+m3espawV80bbBlgfTA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.3"
+      },
+      "engines": {
+        "node": "^18.12.0 || >= 20.9.0"
       }
     },
     "node_modules/cargo-cp-artifact": {
@@ -685,6 +893,80 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.1.tgz",
+      "integrity": "sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.0.3",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+        "css-tree": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -692,6 +974,12 @@
       "dependencies": {
         "ms": "2.0.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -705,6 +993,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/define-data-property": {
@@ -806,6 +1103,27 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
@@ -852,6 +1170,15 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -963,6 +1290,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
@@ -1079,6 +1412,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
@@ -1166,6 +1505,18 @@
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -1180,6 +1531,51 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -1259,6 +1655,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -1274,6 +1676,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1301,6 +1709,124 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.1.tgz",
+      "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.7.2",
+        "cssstyle": "^5.3.1",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/lodash": {
@@ -1344,6 +1870,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -1474,6 +2006,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/mqtt": {
       "version": "5.10.3",
       "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.10.3.tgz",
@@ -1562,6 +2100,31 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -1569,6 +2132,24 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/node-abi": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.78.0.tgz",
+      "integrity": "sha512-E2wEyrgX/CqvicaQYU3Ze1PFGjc4QYPGsjUrlYkqAE0WjHEZwgOsGMPMzkMse4LjJbDmaEuDX3CM036j5K2DSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -1693,6 +2274,18 @@
       "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
       "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1750,6 +2343,68 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -1787,6 +2442,43 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qr-code-styling": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/qr-code-styling/-/qr-code-styling-1.9.2.tgz",
+      "integrity": "sha512-RgJaZJ1/RrXJ6N0j7a+pdw3zMBmzZU4VN2dtAZf8ZggCfRB5stEQ3IoDNGaNhYY3nnZKYlYSLl5YkfWN5dPutg==",
+      "license": "MIT",
+      "dependencies": {
+        "qrcode-generator": "^1.4.4"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/qrcode-generator": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.5.2.tgz",
+      "integrity": "sha512-pItrW0Z9HnDBnFmgiNrY1uxRdri32Uh9EjNYLPVC2zZ3ZRIIEqBoDgm4DkvDwNNDHTK7FNkmr8zAa77BYc9xNw==",
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -1823,6 +2515,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
@@ -1847,6 +2554,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
       "integrity": "sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ=="
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
@@ -1899,6 +2615,12 @@
         "node": "*"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1922,6 +2644,18 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -2114,6 +2848,15 @@
         "string-split-by": "^1.0.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -2234,6 +2977,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -2248,6 +3006,89 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/tar/node_modules/minipass": {
@@ -2266,12 +3107,42 @@
         "bintrees": "1.0.2"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.17",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.17.tgz",
+      "integrity": "sha512-Y1KQBgDd/NUc+LfOtKS6mNsC9CCaH+m2P1RoIZy7RAPo3C3/t8X45+zgut31cRZtZ3xKPjfn3TkGTrctC2TQIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.17"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.17",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.17.tgz",
+      "integrity": "sha512-DieYoGrP78PWKsrXr8MZwtQ7GLCUeLxihtjC1jZsW1DnvSMdKPitJSe8OSYDM2u5H6g3kWJZpePqkp43TfLh0g==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -2288,6 +3159,18 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -2348,10 +3231,55 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -2542,9 +3470,10 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2560,6 +3489,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A discord bot for nottingham hackspace",
   "main": "main.js",
   "scripts": {
-    "test": "node main.js"
+    "test": "node main.js",
+    "docker-build": "docker build -t nh-discord .",
+    "docker-run": "docker run -v ./config.json:/nh-discord/config.json -it nh-discord:latest"
   },
   "repository": {
     "type": "git",
@@ -17,11 +19,14 @@
   },
   "homepage": "https://github.com/AaronJackson/nh-discord#readme",
   "dependencies": {
+    "canvas": "^3.2.0",
     "chart.js": "^4.5.0",
     "discord.js": "^14.16.3",
     "express": "^4.21.2",
+    "jsdom": "^27.0.1",
     "mqtt": "^5.10.3",
     "prom-client": "^15.1.3",
+    "qr-code-styling": "^1.9.2",
     "skia-canvas": "^2.0.2"
   }
 }

--- a/slash_commands/wiki.js
+++ b/slash_commands/wiki.js
@@ -1,0 +1,138 @@
+const { MessageFlags, SlashCommandBuilder, EmbedBuilder, AttachmentBuilder, ButtonBuilder, ButtonStyle, ActionRowBuilder} = require('discord.js');
+const {generateQRCode} = require("../lib/qrcode");
+const {extractToolData} = require("../lib/wiki");
+
+module.exports = function () {
+
+    /**
+     * Injected by main.js
+     */
+    let discordClient;
+
+    const commandName = 'wiki';
+
+    const baseUrl = 'https://wiki.nottinghack.org.uk/'
+
+    this.configure = () => {
+        return  (new SlashCommandBuilder()
+            .setName(commandName)
+            .setDescription('Find a wiki page')
+            .addStringOption(option =>
+                option.setName('query')
+                    .setDescription('page name to find')
+                    .setRequired(true)
+                    .setAutocomplete(true)
+            )).toJSON()
+    }
+
+    this.accept = (name) => {
+        return name === commandName;
+    };
+
+    /**
+     * Handle autocomplete request.
+     */
+    this.autocomplete = async (interaction) => {
+        const focusedOption = interaction.options.getFocused(true);
+        if (!focusedOption.value) {
+            await interaction.respond([])
+            return;
+        }
+
+        const params = new URLSearchParams({
+            action: "query",
+            list: "search",
+            srsearch: focusedOption.value,
+            format: "json",
+            // max 10 embeds per message
+            srlimit: "10",
+        });
+
+        await fetch(`${baseUrl}api.php?${params}`)
+            .then(response => response.json())
+            .then(results => {
+                const options = [];
+                for (const i in (results?.query?.search ?? [])) {
+                    const page = results.query.search[i];
+                    const pageName = page.title;
+                    options.push({name: page.title, value: pageName})
+                }
+
+                return interaction.respond(options)
+            })
+    }
+
+    /**
+     * Handle slash command.
+     */
+    this.execute = async (interaction) => {
+        const pageName = interaction.options.getString('query');
+
+        const params = new URLSearchParams({
+            action: "query",
+            titles: pageName,
+            format: "json",
+            prop: "revisions",
+            formatversion: "2",
+            rvprop: "content",
+            rvslots: "*",
+        });
+
+        const page = await fetch(`${baseUrl}api.php?${params}`)
+            .then(response => response.json())
+            .then(results => {
+                return results.query?.pages[0]?.revisions[0]?.slots?.main || {}
+            })
+
+        const toolData = extractToolData(page.content, ['image'])
+        const fileName = `${toFileName(pageName)}-qr.png`
+        const url = `${baseUrl}wiki/${encodeURI(pageName)}`;
+        const qrCodeBuff = await generateQRCode(url, pageName)
+
+        const wikiEmbed = new EmbedBuilder()
+            .setTitle(pageName)
+            .setURL(url)
+            .setThumbnail(`attachment://${fileName}`)
+
+        if (toolData != null) {
+            wikiEmbed.setFields(toolData)
+        } else {
+            wikiEmbed.setDescription(page.content.length > 512 ? page.content.slice(0, 512)+"..." : page.content)
+        }
+
+        const actionsRow = new ActionRowBuilder()
+            .addComponents(
+                new ButtonBuilder()
+                    .setCustomId('post')
+                    .setLabel('Post to channel')
+                    .setStyle(ButtonStyle.Primary)
+                    .setEmoji('✅')
+            );
+
+        await interaction.reply({
+            content: `\`Posted by ${interaction.user?.globalName ?? interaction.user?.username ?? 'Unknown'}\``,
+            flags: MessageFlags.Ephemeral,
+            embeds: [wikiEmbed],
+            files: [new AttachmentBuilder(qrCodeBuff, {name: fileName})],
+            components: [actionsRow]
+        });
+    };
+
+    /**
+     * Handle any button presses.
+     */
+    this.handleButton = async (interaction) => {
+        switch (interaction.customId) {
+            case "post":
+                await interaction.reply({
+                    content: interaction.message.content,
+                    embeds: interaction.message.embeds,
+                });
+        }
+    }
+
+    function toFileName(str) {
+        return str.toLowerCase().replaceAll(/[^0-9a-z]/ig, "-")
+    }
+
+}


### PR DESCRIPTION
This PR does the following: 

1. Add support for "slash commands".
2. Add a slash command `/wiki` for searching for a wiki page.
3. Generate QR codes for wiki pages found by `/wiki`.
4. Updated README with details on running the bot locally.

Slash commands look like this:

<img width="730" height="331" alt="image" src="https://github.com/user-attachments/assets/2b2177ce-fad3-4905-b16b-108f57b8321a" />

The new command response looks like this for a tool page: 

<img width="691" height="714" alt="image" src="https://github.com/user-attachments/assets/34d12d7f-a2dc-4b7d-8c87-abb0801b5391" />

For a non-tool page it looks like this:

<img width="1848" height="473" alt="image" src="https://github.com/user-attachments/assets/005ea7ae-e6f1-4ee2-90ab-38595cb7e225" />

Which isn't ideal but the PR was already getting quite big so I figured the content could be improved later.

It's an ephemeral response so it's only seen by others if you click "post to channel".

To review this I would hide whitespace changes as there were some indents that got adjusted: https://github.com/NottingHack/nh-instrumentation-discord/pull/4/files?diff=split&w=1