### PR TITLE
Fix various error cases with slash commands

### DIFF
--- a/main.js
+++ b/main.js
@@ -54,20 +54,23 @@ discordClient.on(Events.MessageCreate, function(message)  {
  */
 discordClient.on(Events.InteractionCreate, (interaction) => {
     // if the interaction is a button press get the command name from the interaction (todo: is there a better way?)
-    const cmd = slashCommands.find((cmd) => cmd.accept(interaction.commandName ?? interaction.message?.interaction?.commandName))
-    if (cmd) {
-        if (interaction.isAutocomplete()) {
-            cmd.autocomplete(interaction)
-        } else if (interaction.isButton()) {
-            cmd.handleButton(interaction)
-        } else if (interaction.isCommand()) {
-            cmd.execute(interaction)
+    try {
+        const cmd = slashCommands.find((cmd) => cmd.accept(interaction.commandName ?? interaction.message?.interaction?.commandName))
+        if (cmd) {
+            if (interaction.isAutocomplete()) {
+                cmd.autocomplete(interaction)
+            } else if (interaction.isButton()) {
+                cmd.handleButton(interaction)
+            } else if (interaction.isCommand()) {
+                cmd.execute(interaction)
+            } else {
+                console.warn("Unknown interaction type was ignored", interaction.type)
+            }
         } else {
-            console.warn("Unknown interaction type was ignored", interaction.type)
+            console.error(`Failed to find command for interaction: ${interaction.commandName} (customId: ${interaction.customId})`)
         }
-    } else {
-        console.log(interaction)
-        console.error(`Failed to find command for interaction: ${interaction.commandName} (customId: ${interaction.customId})`)
+    } catch (err) {
+        console.error(`Failed to handle interaction`, err)
     }
 })
 

--- a/main.js
+++ b/main.js
@@ -55,22 +55,22 @@ discordClient.on(Events.MessageCreate, function(message)  {
 discordClient.on(Events.InteractionCreate, (interaction) => {
     // if the interaction is a button press get the command name from the interaction (todo: is there a better way?)
     try {
-        const cmd = slashCommands.find((cmd) => cmd.accept(interaction.commandName ?? interaction.message?.interaction?.commandName))
+        const cmd = slashCommands.find((cmd) => cmd.accept(interaction.commandName ?? interaction.message?.interaction?.commandName));
         if (cmd) {
             if (interaction.isAutocomplete()) {
-                cmd.autocomplete(interaction)
+                cmd.autocomplete(interaction);
             } else if (interaction.isButton()) {
-                cmd.handleButton(interaction)
+                cmd.handleButton(interaction);
             } else if (interaction.isCommand()) {
-                cmd.execute(interaction)
+                cmd.execute(interaction);
             } else {
-                console.warn("Unknown interaction type was ignored", interaction.type)
+                console.warn("Unknown interaction type was ignored", interaction.type);
             }
         } else {
-            console.error(`Failed to find command for interaction: ${interaction.commandName} (customId: ${interaction.customId})`)
+            console.error(`Failed to find command for interaction: ${interaction.commandName} (customId: ${interaction.customId})`);
         }
     } catch (err) {
-        console.error(`Failed to handle interaction`, err)
+        console.error(`Failed to handle interaction`, err);
     }
 })
 

--- a/slash_commands/wiki.js
+++ b/slash_commands/wiki.js
@@ -1,4 +1,12 @@
-const { MessageFlags, SlashCommandBuilder, EmbedBuilder, AttachmentBuilder, ButtonBuilder, ButtonStyle, ActionRowBuilder} = require('discord.js');
+const {
+    MessageFlags,
+    SlashCommandBuilder,
+    EmbedBuilder,
+    AttachmentBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    ActionRowBuilder
+} = require('discord.js');
 const {generateQRCode} = require("../lib/qrcode");
 const {extractToolData} = require("../lib/wiki");
 
@@ -14,7 +22,7 @@ module.exports = function () {
     const baseUrl = 'https://wiki.nottinghack.org.uk/'
 
     this.configure = () => {
-        return  (new SlashCommandBuilder()
+        return (new SlashCommandBuilder()
             .setName(commandName)
             .setDescription('Find a wiki page')
             .addStringOption(option =>
@@ -66,6 +74,12 @@ module.exports = function () {
      * Handle slash command.
      */
     this.execute = async (interaction) => {
+
+        // Create "thinking..." response
+        await interaction.deferReply({
+            flags: MessageFlags.Ephemeral,
+        })
+
         const pageName = interaction.options.getString('query');
 
         const params = new URLSearchParams({
@@ -81,8 +95,27 @@ module.exports = function () {
         const page = await fetch(`${baseUrl}api.php?${params}`)
             .then(response => response.json())
             .then(results => {
-                return results.query?.pages[0]?.revisions[0]?.slots?.main || {}
+                const pages = results.query?.pages
+                if ((pages || []).length === 0) {
+                    return null;
+                }
+                const revisions = pages[0]?.revisions;
+                if ((revisions || []).length === 0) {
+                    return null;
+                }
+                return revisions[0]?.slots?.main || null;
             })
+            .catch((err) => {
+                console.error('Failed to fetch wiki page', err);
+            })
+
+        if (!page) {
+            await interaction.editReply({
+                content: `Sorry, page was not available.`,
+                flags: MessageFlags.Ephemeral,
+            });
+            return;
+        }
 
         const toolData = extractToolData(page.content, ['image'])
         const fileName = `${toFileName(pageName)}-qr.png`
@@ -97,7 +130,7 @@ module.exports = function () {
         if (toolData != null) {
             wikiEmbed.setFields(toolData)
         } else {
-            wikiEmbed.setDescription(page.content.length > 512 ? page.content.slice(0, 512)+"..." : page.content)
+            wikiEmbed.setDescription(page.content.length > 512 ? page.content.slice(0, 512) + "..." : page.content)
         }
 
         const actionsRow = new ActionRowBuilder()
@@ -109,7 +142,7 @@ module.exports = function () {
                     .setEmoji('✅')
             );
 
-        await interaction.reply({
+        await interaction.editReply({
             content: `\`Posted by ${interaction.user?.globalName ?? interaction.user?.username ?? 'Unknown'}\``,
             flags: MessageFlags.Ephemeral,
             embeds: [wikiEmbed],

--- a/slash_commands/wiki.js
+++ b/slash_commands/wiki.js
@@ -92,7 +92,7 @@ module.exports = function () {
             rvslots: "*",
         });
 
-        const page = await fetch(`${baseUrl}api.php?${params}`)
+        const pageContent = await fetch(`${baseUrl}api.php?${params}`)
             .then(response => response.json())
             .then(results => {
                 const pages = results.query?.pages
@@ -103,13 +103,13 @@ module.exports = function () {
                 if ((revisions || []).length === 0) {
                     return null;
                 }
-                return revisions[0]?.slots?.main || null;
+                return revisions[0]?.slots?.main?.content || '';
             })
             .catch((err) => {
                 console.error('Failed to fetch wiki page', err);
             })
 
-        if (!page) {
+        if (!pageContent) {
             await interaction.editReply({
                 content: `Sorry, page was not available.`,
                 flags: MessageFlags.Ephemeral,
@@ -117,7 +117,7 @@ module.exports = function () {
             return;
         }
 
-        const toolData = extractToolData(page.content, ['image'])
+        const toolData = extractToolData(pageContent, ['image'])
         const fileName = `${toFileName(pageName)}-qr.png`
         const url = `${baseUrl}wiki/${encodeURI(pageName)}`;
         const qrCodeBuff = await generateQRCode(url, pageName)
@@ -130,7 +130,7 @@ module.exports = function () {
         if (toolData != null) {
             wikiEmbed.setFields(toolData)
         } else {
-            wikiEmbed.setDescription(page.content.length > 512 ? page.content.slice(0, 512) + "..." : page.content)
+            wikiEmbed.setDescription(pageContent.length > 512 ? pageContent.slice(0, 512) + "..." : pageContent)
         }
 
         const actionsRow = new ActionRowBuilder()


### PR DESCRIPTION
1. Adds global try/catch for all interaction handlers (prevent uncaught exception crashing bot).
2. Do not assume page has revisions available.
3. Use deferred responses for wiki page result (should fix "unknown interaction") errors.